### PR TITLE
Swarm: remove artifactory-pro.yml deprecated props

### DIFF
--- a/swarm/artifactory-pro.yml
+++ b/swarm/artifactory-pro.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   postgresql:
     image: docker.bintray.io/postgres:9.5.2
-    container_name: postgresql
     ports:
      - 5432:5432
     environment:
@@ -18,7 +17,6 @@ services:
       replicas: 1
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.4
-    container_name: artifactory
     ports:
      - 8081:8081
     depends_on:
@@ -40,7 +38,6 @@ services:
     restart: always
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.4
-    container_name: nginx
     ports:
      - 80:80
      - 443:443


### PR DESCRIPTION
As of Docker Engine 17.0.6, we get the following warning message:

```
Ignoring deprecated options:
container_name: Setting the container name is not supported.
```

The container name in a stack is defined by the service name in the stacks file.
So, removing the name definition removes the