### PR TITLE
Pro Swarm sample: Fixing to run in current Swarm

### DIFF
--- a/swarm/artifactory-pro.yml
+++ b/swarm/artifactory-pro.yml
@@ -1,8 +1,9 @@
 version: '3'
+
 services:
+
   postgresql:
     image: docker.bintray.io/postgres:9.5.2
-    container_name: postgresql
     ports:
      - 5432:5432
     environment:
@@ -10,15 +11,20 @@ services:
      # The following must match the DB_USER and DB_PASSWORD values passed to Artifactory
      - POSTGRES_USER=artifactory
      - POSTGRES_PASSWORD=password
-    volumes:
-     - /data/postgresql:/var/lib/postgresql/data
-    restart: always
+    #volumes:
+    # - artifactory:/var/lib/postgresql/data
     deploy:
       mode: replicated
       replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints: [node.role != manager]
+
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.4
-    container_name: artifactory
     ports:
      - 8081:8081
     depends_on:
@@ -26,10 +32,14 @@ services:
     deploy:
       mode: replicated
       replicas: 1
-    links:
-     - postgresql
-    volumes:
-     - /data/artifactory:/var/opt/jfrog/artifactory
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints: [node.role != manager]
+    #volumes:
+    # - artifactory:/var/opt/jfrog/artifactory
     environment:
      - DB_TYPE=postgresql
      # The following must match the POSTGRES_USER and POSTGRES_PASSWORD values passed to PostgreSQL
@@ -37,10 +47,9 @@ services:
      - DB_PASSWORD=password
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
-    restart: always
+
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.4
-    container_name: nginx
     ports:
      - 80:80
      - 443:443
@@ -49,11 +58,17 @@ services:
     deploy:
       mode: replicated
       replicas: 1
-    links:
-     - artifactory
-    volumes:
-     - /data/nginx:/var/opt/jfrog/nginx
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints: [node.role != manager]
+    #volumes:
+    # - artifactory:/var/opt/jfrog/nginx
     environment:
      - ART_BASE_URL=http://artifactory:8081/artifactory
      - SSL=true
-    restart: always
+
+#volumes:
+#  artifactory:


### PR DESCRIPTION
* Replacing the volumes definition to a named one
* Adding the restart policy with a delay
* Adding a placement to be NOT the swarm manager nodes (by default docker documentation)
* Defining the named volume, without the driver